### PR TITLE
Skip existing namespaces unless forced

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,9 +29,14 @@ chmod +x deploy-students.sh monitor-students.sh
 # Deploy 5 students with your cluster domain
 ./deploy-students.sh -n 5 -d apps.your-cluster-domain.com
 
+# Force redeploy if namespaces already exist
+./deploy-students.sh -n 5 -d apps.your-cluster-domain.com --force
+
 # Check deployment status
 ./monitor-students.sh
 ```
+
+If a namespace already exists, deployment is skipped unless you use `--force`.
 
 ### Option B: Using Make (if you have make installed)
 ```bash

--- a/README.md
+++ b/README.md
@@ -35,12 +35,17 @@ chmod +x deploy-students.sh
 # Deploy 5 students (student01-student05)
 ./deploy-students.sh -n 5 -d apps.your-cluster.com
 
+# Force redeploy if namespaces already exist
+./deploy-students.sh -n 5 -d apps.your-cluster.com --force
+
 # Deploy specific students
 ./deploy-students.sh -s alice,bob,charlie -d apps.your-cluster.com
 
 # Clean up environments
 ./deploy-students.sh -n 5 --cleanup
 ```
+
+If a student's namespace already exists, the script logs a warning and skips deployment. Use `--force` to redeploy.
 
 ### 3. Access Student Environments
 


### PR DESCRIPTION
## Summary
- add `--force` option to `deploy-students.sh`
- skip deployment if namespace already exists unless forced
- document new force/skip behavior in README and QUICKSTART

## Testing
- `bash -n deploy-students.sh monitor-students.sh git-push.sh startup.sh`
- `make test` *(fails: required command 'oc' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68512d00c384832db9932328b7d08e83