### PR TITLE
Fix build config path

### DIFF
--- a/build-and-verify.sh
+++ b/build-and-verify.sh
@@ -13,7 +13,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Apply Shipwright build configuration
 echo "[INFO] Applying Shipwright configuration..."
-oc apply -f "${SCRIPT_DIR}/shipwright/"
+oc apply -f "${SCRIPT_DIR}/shipwright/build.yaml"
 
 # Start the build and capture the buildrun name
 echo "[INFO] Starting build..."


### PR DESCRIPTION
## Summary
- run `oc apply` with `build.yaml` instead of the directory

## Testing
- `shellcheck build-and-verify.sh`
- `bash -n build-and-verify.sh`
- `./build-and-verify.sh` *(with dummy `oc`)*

------
https://chatgpt.com/codex/tasks/task_e_68514446b2dc832daac378bd1484b34e