### PR TITLE
Fix Pulumi install path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | b
 
 # Pulumi
 RUN curl -fsSL https://get.pulumi.com | sh \
-    && cp /root/.pulumi/bin/pulumi /usr/local/bin/ \
+    && cp $HOME/.pulumi/bin/pulumi /usr/local/bin/ \
     && chmod +x /usr/local/bin/pulumi
 
 # ArgoCD CLI (Linux binaries)


### PR DESCRIPTION
## Summary
- ensure Pulumi binary is copied from the actual install directory

## Testing
- `make test` *(fails: required command 'oc' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517eaa0d50832d970ee0f572262f55