### PR TITLE
Fix extension IDs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,10 +79,9 @@ USER root
 RUN HOME=/home/coder code-server \
     --user-data-dir /home/coder/.local/share/code-server \
     --install-extension ms-python.python \
-    --install-extension ms-vscode.vscode-json \
     --install-extension redhat.vscode-yaml \
     --install-extension ms-kubernetes-tools.vscode-kubernetes-tools \
-    --install-extension ms-vscode.vscode-docker \
+    --install-extension ms-azuretools.vscode-docker \
     --install-extension vscjava.vscode-java-pack \
     --install-extension ms-vscode.vscode-typescript-next \
     --install-extension esbenp.prettier-vscode \


### PR DESCRIPTION
## Summary
- remove JSON extension (it's builtin)
- fix Docker extension ID

## Testing
- `curl -I -L https://marketplace.visualstudio.com/items?itemName=ms-azuretools.vscode-docker | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_685189144f74832d9308fa4f5b2db8f6