### PR TITLE
Increase build timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ The project uses Shipwright for automated builds:
 The script detects whether you are on an `x86_64` or `arm64` system and passes
 the correct architecture to Shipwright so multi-arch builds work out of the box.
 
+You can override the default build timeout by setting the `BUILD_TIMEOUT`
+environment variable before running the script.
+
 ### 2. Deploy Students
 
 Use the management script to deploy multiple student environments:

--- a/build-and-verify.sh
+++ b/build-and-verify.sh
@@ -27,7 +27,7 @@ echo "✅ [INFO] Preflight checks passed."
 
 # === Setup Variables ===
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BUILD_TIMEOUT="${BUILD_TIMEOUT:-600s}"  # 10 minutes default
+BUILD_TIMEOUT="${BUILD_TIMEOUT:-1200s}"  # 20 minutes default
 
 # === Detect Architecture ===
 detected_arch=$(uname -m)


### PR DESCRIPTION
## Summary
- bump default `BUILD_TIMEOUT` to 20 minutes
- document how to override `BUILD_TIMEOUT`

## Testing
- `bash -n build-and-verify.sh`

------
https://chatgpt.com/codex/tasks/task_e_685286b79eec832d8c25110d5ba0d206