### PR TITLE
Fix COPY templates command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN echo 'source <(oc completion bash)' >> /home/coder/.bashrc && \
 # Configs and templates
 COPY --chown=1001:1001 gitconfig-template /home/coder/.gitconfig-template
 COPY --chown=1001:1001 startup.sh /home/coder/startup.sh
-COPY --chown=1001:1001 workshop-templates/ /home/coder/workspace/templates/ || true
+COPY --chown=1001:1001 workshop-templates/ /home/coder/workspace/templates/
 
 RUN chmod +x /home/coder/startup.sh && \
     chown -R 1001:1001 /home/coder && \


### PR DESCRIPTION
## Summary
- remove `|| true` from the `COPY` instruction in Dockerfile

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `docker build -t testimage .` *(fails: Docker daemon not running)*

------
https://chatgpt.com/codex/tasks/task_e_68528a2f5dc4832db35453a0fa7795d2