### PR TITLE
Update limits and add workshop repo helper

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Kevin Biot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ After deployment, each student will have:
 
 **For students new to code-server/VS Code**: Direct them to click on `STUDENT-QUICK-START.md` in their workspace file explorer for a complete tutorial on using the environment.
 
+### 4. Populate Workspace with Workshop Repos (optional)
+Run the helper script inside a student terminal to clone the training repositories:
+```bash
+./clone-workshop-repos.sh
+```
+
 ## Architecture
 
 ### Image Contents
@@ -81,9 +87,9 @@ Each student gets their own namespace with:
 ## Configuration
 
 ### Resource Limits (per student)
-- **CPU**: 100m request, 500m limit
-- **Memory**: 512Mi request, 1Gi limit
-- **Storage**: 2Gi persistent volume
+- **CPU**: 200m request, 1000m limit
+- **Memory**: 1Gi request, 2Gi limit
+- **Storage**: 1Gi persistent volume
 - **Pods**: Maximum 5 pods per namespace
 
 ### Customization
@@ -165,4 +171,4 @@ Remove all student environments:
 
 ## License
 
-This project is open source. Please ensure compliance with all included software licenses.
+This project is licensed under the [MIT License](LICENSE).

--- a/STUDENT-QUICK-START.md
+++ b/STUDENT-QUICK-START.md
@@ -262,6 +262,12 @@ helm version
 
 ## 🎯 **Step 8: Workshop-Specific Getting Started**
 
+First, clone the workshop repositories (skip if they are already present):
+```bash
+cd ~/workspace
+./clone-workshop-repos.sh
+```
+
 ### Day 1: Pulumi Infrastructure Setup
 ```bash
 # Navigate to Day 1 exercises

--- a/clone-workshop-repos.sh
+++ b/clone-workshop-repos.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# clone-workshop-repos.sh - Clone DevOps workshop repositories into the workspace
+
+set -euo pipefail
+
+WORKSPACE_DIR="${WORKSPACE_DIR:-$HOME/workspace}"
+REPOS=(
+    "https://github.com/kevin-biot/IaC.git"
+    "https://github.com/kevin-biot/devops-workshop.git"
+)
+
+mkdir -p "$WORKSPACE_DIR"
+cd "$WORKSPACE_DIR"
+
+for repo in "${REPOS[@]}"; do
+    name=$(basename "$repo" .git)
+    if [ -d "$name" ]; then
+        echo "[INFO] $name already cloned, skipping"
+    else
+        echo "[INFO] Cloning $repo"
+        git clone "$repo"
+    fi
+done

--- a/preflight-checks.sh
+++ b/preflight-checks.sh
@@ -3,7 +3,8 @@
 
 set -euo pipefail
 
-echo "[INFO] Starting Darwin-based build verification"
+OS_NAME=$(uname -s)
+echo "[INFO] Starting build verification on ${OS_NAME}"
 
 # === Preflight CLI Checks ===
 for cmd in oc kubectl tkn yq argocd pulumi; do

--- a/student-template.yaml
+++ b/student-template.yaml
@@ -297,7 +297,7 @@ parameters:
   value: image-registry.openshift-image-registry.svc:5000/devops/code-server-student:latest
 - name: STORAGE_SIZE
   description: PVC storage size
-  value: 5Gi
+  value: 1Gi
 - name: STORAGE_CLASS
   description: Storage class for PVC
   value: gp3-csi


### PR DESCRIPTION
## Summary
- sync README limits with template defaults
- default PVC to 1Gi
- add MIT license
- add helper script to clone workshop repos
- clarify OS detection in preflight checks
- document cloning script in README and Student Quick Start

## Testing
- `shellcheck preflight-checks.sh clone-workshop-repos.sh`
- `bash -n preflight-checks.sh clone-workshop-repos.sh`


------
https://chatgpt.com/codex/tasks/task_e_6852c2f73578832dbee0f2d34ad45e65